### PR TITLE
Fix Flink engine version requirements

### DIFF
--- a/versioned_docs/version-2.1.0/flink/quick-start.md
+++ b/versioned_docs/version-2.1.0/flink/quick-start.md
@@ -6,7 +6,7 @@
 
 > If you are familiar with `Flink` or have prepared the `Flink` operating environment, you can ignore this step. `Flink` does not require any special configuration.
 
-Please [download Flink](https://flink.apache.org/downloads.html) first, please choose Flink version >= 1.9.0 and version < version < 1.14.x . The download is complete to [install Flink](https://nightlies.apache.org/flink/flink-docs-release-1.14/zh/docs/deployment/resource-providers/standalone/overview/)
+Please [download Flink](https://flink.apache.org/downloads.html) first, please choose Flink version >= 1.12.0 and version < version < 1.14.x . The download is complete to [install Flink](https://nightlies.apache.org/flink/flink-docs-release-1.14/zh/docs/deployment/resource-providers/standalone/overview/)
 
 ## Step 2: Download seatunnel
 

--- a/versioned_docs/version-2.1.1/start/local.mdx
+++ b/versioned_docs/version-2.1.1/start/local.mdx
@@ -15,7 +15,7 @@ Before you getting start the local run, you need to make sure you already have i
 * Download the engine, you can choose and download one of them from below as your favour, you could see more information about [why we need engine in SeaTunnel](../faq.md#why-i-should-install-computing-engine-like-spark-or-flink)
   * Spark: Please [download Spark](https://spark.apache.org/downloads.html) first(**required version >= 2 and version < 3.x **). For more information you could
   see [Getting Started: standalone](https://spark.apache.org/docs/latest/spark-standalone.html#installing-spark-standalone-to-a-cluster)
-  * Flink: Please [download Flink](https://flink.apache.org/downloads.html) first(**required version >= 1.9.0 and version < 1.14.x **). For more information you could see [Getting Started: standalone](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/deployment/resource-providers/standalone/overview/)
+  * Flink: Please [download Flink](https://flink.apache.org/downloads.html) first(**required version >= 1.12.0 and version < version < 1.14.x **). For more information you could see [Getting Started: standalone](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/deployment/resource-providers/standalone/overview/)
 
 ## Installation
 

--- a/versioned_docs/version-2.1.2/start/local.mdx
+++ b/versioned_docs/version-2.1.2/start/local.mdx
@@ -15,7 +15,7 @@ Before you getting start the local run, you need to make sure you already have i
 * Download the engine, you can choose and download one of them from below as your favour, you could see more information about [why we need engine in SeaTunnel](../faq.md#why-i-should-install-computing-engine-like-spark-or-flink)
   * Spark: Please [download Spark](https://spark.apache.org/downloads.html) first(**required version >= 2 and version < 3.x **). For more information you could
   see [Getting Started: standalone](https://spark.apache.org/docs/latest/spark-standalone.html#installing-spark-standalone-to-a-cluster)
-  * Flink: Please [download Flink](https://flink.apache.org/downloads.html) first(**required version >= 1.9.0 and version < 1.14.x **). For more information you could see [Getting Started: standalone](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/deployment/resource-providers/standalone/overview/)
+  * Flink: Please [download Flink](https://flink.apache.org/downloads.html) first(**required version >= 1.12.0 and version < version < 1.14.x **). For more information you could see [Getting Started: standalone](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/deployment/resource-providers/standalone/overview/)
 
 ## Installation
 


### PR DESCRIPTION
Flink 1.13.6 version is compatible with 1.12, but not applicable to below 1.12