### PR TITLE
[Doc] update 2.1.3 version Kafka Examples docs 

### DIFF
--- a/versioned_docs/version-2.1.3/connector/sink/Kafka-sink-parameter.md
+++ b/versioned_docs/version-2.1.3/connector/sink/Kafka-sink-parameter.md
@@ -56,7 +56,7 @@ Sink plugin common parameters, please refer to [Sink Plugin](common-options.md) 
 
 ```bash
 kafka {
-    topic = "seatunnel"
+    topics = "seatunnel"
     producer.bootstrap.servers = "localhost:9092"
 }
 ```


### PR DESCRIPTION
When kafka is used as a connector sink, the parameter should be topics, not topic.
I practice according to the cases in the current document and always report errors. Until I read the source code and found that the parameter should be topics.