### PR TITLE
Fix doc for LocalFile

### DIFF
--- a/versioned_docs/version-2.3.0/seatunnel-engine/checkpoint-storage.md
+++ b/versioned_docs/version-2.3.0/seatunnel-engine/checkpoint-storage.md
@@ -120,7 +120,7 @@ seatunnel:
         type: hdfs
         max-retained: 3
         plugin-config:
+          namespace: /tmp/seatunnel/checkpoint_snapshot    
           storage-type: hdfs
-          fs.defaultFS: /tmp/ # Ensure that the directory has written permission 
 
 ```


### PR DESCRIPTION
when run job on Seatunel Engine cluster, it will report errors : ``` No scheme in default FS: /tmp/```,  if  dont set  `fs.defaultFS`,  Hdfs local file will use  `file:///`,  then the etl job  can work.  Or  can set properties like this: ` fs.defaultFS: file:///`
